### PR TITLE
Create Globals.js and host variables instead of passing as props

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,11 @@
 import Chessboard from "./components/Chessboard"
 import "./App.css"
 
-const BOARDSIZE = 8;
-const TILESIZE = 128;
-
 function App() {
 
   return (
     <>
-        <Chessboard 
-          boardSize={BOARDSIZE}
-          tileSize={TILESIZE}
-          />
+        <Chessboard />
     </>
   );
 }

--- a/src/components/ChessPiece.tsx
+++ b/src/components/ChessPiece.tsx
@@ -2,7 +2,6 @@ export interface ChessPieceProps {
     id: string,
     x: number,
     y: number,
-    size: number,
     imagePath: string,
     color: string,
 };
@@ -14,10 +13,6 @@ function ChessPiece(props: ChessPieceProps) {
             className={"size-full"}
             chess-piece={"true"}
             style={{ 
-                //left: (props.x * props.size) + "px", 
-                //top: (props.y * props.size) + "px", 
-                //height: props.size + "px",
-                //width: props.size + "px",
                 zIndex: 1,
                 cursor: "grab"
             }}>

--- a/src/components/ChessTile.tsx
+++ b/src/components/ChessTile.tsx
@@ -2,11 +2,12 @@ import ChessPiece, { ChessPieceProps } from "./ChessPiece"
 import { Coordinate, TileColor } from "./CommonTypes";
 import "./ChessTile.css";
 
+import Globals from "../config/globals"
+
 interface ChessTileInterface {
     id: string,
     x: number,
     y: number,
-    size: number,
     color: TileColor;
     getCenter(): Coordinate
 };
@@ -15,7 +16,6 @@ interface Props {
     id: string,
     x: number,
     y: number,
-    size: number,
     color: TileColor,
     border: TileColor,
     getCenter(): Coordinate,
@@ -29,8 +29,8 @@ const BLACK_COLOR = "chocolate";
 const HIGHLIGHT_COLOR = "lightgreen";
 
 function ChessTile(props: Props) {
-    const xPx: string = `${(props.x * props.size)}px`;
-    const yPx: string = `${(props.y * props.size)}px`;
+    const xPx: string = `${(props.x * Globals.TILESIZE)}px`;
+    const yPx: string = `${(props.y * Globals.TILESIZE)}px`;
 
     let color = WHITE_COLOR;
     if (props.color === "black") {
@@ -51,9 +51,9 @@ function ChessTile(props: Props) {
                         left: xPx, 
                         top: yPx, 
                         backgroundColor: color,
-                        height: props.size + "px",
-                        width: props.size + "px",
-                        border: `${props.size / 8}px solid ${props.border === "white" ? WHITE_COLOR : BLACK_COLOR }`,
+                        height: Globals.TILESIZE + "px",
+                        width: Globals.TILESIZE + "px",
+                        border: `${Globals.TILESIZE / Globals.BORDER_FRACTION}px solid ${props.border === "white" ? WHITE_COLOR : BLACK_COLOR }`,
                         //cursor: props.drawPiece.color === PLAYER_COLOR ? "grab" : "default",
                     }}
                     id={props.id}
@@ -63,7 +63,6 @@ function ChessTile(props: Props) {
                             key={props.drawPiece.id}
                             x={props.drawPiece.x}
                             y={props.drawPiece.y}
-                            size={props.drawPiece.size}
                             color={props.drawPiece.color}
                             imagePath={props.drawPiece.imagePath}
                         />
@@ -80,9 +79,9 @@ function ChessTile(props: Props) {
                         left: xPx, 
                         top: yPx, 
                         backgroundColor: color,
-                        height: props.size + "px",
-                        width: props.size + "px",
-                        border: `${props.size / 8}px solid ${props.border === "white" ? "cornsilk" : "chocolate"}`
+                        height: Globals.TILESIZE + "px",
+                        width: Globals.TILESIZE + "px",
+                        border: `${Globals.TILESIZE / Globals.BORDER_FRACTION}px solid ${props.border === "white" ? "cornsilk" : "chocolate"}`
                     }}
                     id={props.id}
                     key={props.id}>

--- a/src/components/Chessboard.tsx
+++ b/src/components/Chessboard.tsx
@@ -2,7 +2,9 @@ import { useEffect, useState } from 'react';
 
 import { ChessPieceProps } from "./ChessPiece";
 import ChessTile, { ChessTileInterface } from "./ChessTile"
-import { Coordinate, MousePos, SizeProps, TileColor } from "./CommonTypes";
+import { Coordinate, MousePos, TileColor } from "./CommonTypes";
+
+import Globals from "../config/globals";
 
 import "./Chessboard.css";
 
@@ -58,12 +60,11 @@ function getTileKey(row: number, col: number): string {
     return `${colLetter}${row}`;
 };
 
-function Chessboard(props: SizeProps) {
+function Chessboard() {
 
     // TODO: Chessboard does not need to be a state object.
     const [chessboard, setChessboard] = useState<TileGrid>({});
 
-    // 
     const [pieces, setPieces] = useState<PieceDict>({});
     const [highlightedTile, setHighlightedTile] = useState("A1");
     const [shiftHeld, setShiftHeld] = useState(false);
@@ -79,7 +80,7 @@ function Chessboard(props: SizeProps) {
 
         const initialPieces = []
 
-        for (let i = 0; i < props.boardSize; i++) {
+        for (let i = 0; i < Globals.BOARDSIZE; i++) {
             const columnPieces = []
             const columnLetter = translationKey[i];
 
@@ -133,7 +134,6 @@ function Chessboard(props: SizeProps) {
                 id: key,
                 x: tile.x,
                 y: tile.y,
-                size: tile.size,
                 color: piece.color,
                 imagePath: `src/assets/images/${piece.name}-${piece.color[0]}.png`
             };
@@ -149,15 +149,15 @@ function Chessboard(props: SizeProps) {
         
         const newChessboard: TileGrid = {};
 
-        for (let row = props.boardSize; row >= 1; row-- ) {
-            for (let col = 1; col <= props.boardSize; col++ ) {
+        for (let row = Globals.BOARDSIZE; row >= 1; row-- ) {
+            for (let col = 1; col <= Globals.BOARDSIZE; col++ ) {
                 /*
                     Tiles are represents as letter-number, where a letter is a
                     reference to the column, and the number is the row that the
                     tile is in. For example, the first column is A and the last
                     column is H. Importantly, numbering starts from the bottom to
                     the top, rather than top to bottom, so to instantiate the 
-                    board, I must begin at props.boardSize.
+                    board, I must begin at Globals.BOARDSIZE.
                 */
     
                 // Alternate tile colors by row evenness
@@ -179,12 +179,11 @@ function Chessboard(props: SizeProps) {
                     id: tileKey,
                     x: col,
                     y: row,
-                    size: props.tileSize,
                     color: tileColor,
                     getCenter(): Coordinate {
                         const coord: Coordinate = {
-                            x: ((this.x - 1) * props.tileSize) / 2,
-                            y: ((this.y - 1) * props.tileSize) / 2,
+                            x: ((this.x - 1) * Globals.TILESIZE) / 2,
+                            y: ((this.y - 1) * Globals.TILESIZE) / 2,
                         };
                         return coord;
                     }
@@ -237,7 +236,6 @@ function Chessboard(props: SizeProps) {
                 key={chessboard[tile].id}
                 x={chessboard[tile].x}
                 y={chessboard[tile].y}
-                size={chessboard[tile].size}
                 color={chessboard[tile].color}
                 border={chessboard[tile].color}
                 getCenter={chessboard[tile].getCenter}
@@ -255,20 +253,17 @@ function Chessboard(props: SizeProps) {
                 src={piece.imagePath}
                 style={{
                     position: "absolute",
-                    left: mousePosition.x - piece.size / 2,
-                    top: mousePosition.y - piece.size / 2,
-                    width: piece.size + "px",
-                    height: piece.size + "px",
+                    left: mousePosition.x - Globals.TILESIZE / 2,
+                    top: mousePosition.y - Globals.TILESIZE / 2,
+                    width: `${Globals.TILESIZE}px`,
+                    height: `${Globals.TILESIZE}px`,
                 }}
                 />
         )
     };
 
-    /* 
-        TODO: Probably using too many things here. Props especially doesn't
-        need to be a referesh trigger. Read up on hooks and see what can be
-        better-placed.
-    */ 
+     
+    // TODO: Probably using too many things here. Read up on hooks and see what can be better-placed.
     useEffect(() => {
         function moveTile(xMovement: number, yMovement: number) {
             const tileLetter = highlightedTile[0];
@@ -280,14 +275,14 @@ function Chessboard(props: SizeProps) {
 
             console.log(`Current X/Y before movement is ${x}/${y}`);
             // Horizontal clamping
-            if (destX < 1 || destX > props.boardSize) {
-                destX = destX < 1 ? 1 : props.boardSize;
+            if (destX < 1 || destX > Globals.BOARDSIZE) {
+                destX = destX < 1 ? 1 : Globals.BOARDSIZE;
                 console.log("Hit horizontal limit.");
             }
         
             // Vertical clamping
-            if (destY < 1 || destY > props.boardSize) {
-                destY = destY < 1 ? 1 : props.boardSize;
+            if (destY < 1 || destY > Globals.BOARDSIZE) {
+                destY = destY < 1 ? 1 : Globals.BOARDSIZE;
                 console.log("Hit vertical limit.");
             }
     
@@ -302,7 +297,7 @@ function Chessboard(props: SizeProps) {
         };
     
         function handleKeyDown(event: KeyboardEvent) {
-            const distance = shiftHeld ? props.boardSize : 1;
+            const distance = shiftHeld ? Globals.BOARDSIZE : 1;
             switch (event.key) {
                 case "Shift":
                     if (!shiftHeld) {
@@ -417,9 +412,9 @@ function Chessboard(props: SizeProps) {
             document.removeEventListener("mousemove", updateMousePosition);
         };
 
-    }, [draggingPiece, mousePosition, highlightedTile, shiftHeld, pieces, props]);
+    }, [draggingPiece, mousePosition, highlightedTile, shiftHeld, pieces]);
 
-    const SIZECALC = `${props.tileSize * props.boardSize}px`;
+    const SIZECALC = `${Globals.TILESIZE * Globals.BOARDSIZE}px`;
 
     return (
         <div 

--- a/src/config/globals.tsx
+++ b/src/config/globals.tsx
@@ -1,0 +1,8 @@
+// Global variables that should not change over the course of the program.
+const Globals = {
+    BOARDSIZE: 8,
+    TILESIZE: 128,
+    BORDER_FRACTION: 8,
+};
+
+export default Globals;


### PR DESCRIPTION
Originally, the tilesize/boardsize were being passed around as props. This isn't a good way to go about that, so I've created config/globals.js and placed a Globals object in that for easier global code reference.