### PR TITLE
Dragging fixes

### DIFF
--- a/src/components/Chessboard.tsx
+++ b/src/components/Chessboard.tsx
@@ -207,6 +207,7 @@ function Chessboard() {
                         src={piece.imagePath}
                         style={{
                             position: "absolute",
+                            zIndex: Globals.Z_INDEX.DRAGGED_PIECE,
                             left: mousePosition.x - Globals.TILESIZE / 2,
                             top: mousePosition.y - Globals.TILESIZE / 2,
                             width: `${Globals.TILESIZE}px`,
@@ -236,7 +237,9 @@ function Chessboard() {
         return null
     };
 
-    const allPieces = getPieceDict().map((piece) => piece.buildElement());   
+    const allPieces = getPieceDict()
+        .filter(piece => piece.id !== draggingPiece) // Don't render the piece being dragged
+        .map(piece => piece.buildElement());
      
     // TODO: Probably using too many things here. Read up on hooks and see what can be better-placed.
     useEffect(() => {

--- a/src/config/globals.tsx
+++ b/src/config/globals.tsx
@@ -7,6 +7,7 @@ const Globals = {
         BOARD: 0,
         HIGHLIGHT: 1,
         PIECE: 2,
+        DRAGGED_PIECE: 10,
     },
 };
 


### PR DESCRIPTION
Fixes #6 

Highlighting and draw-under issues are resolved by modifying the z-index of the dragged piece.
Hiding the original piece is done by filtering out any pieces whose ID matches the dragged piece.