### PR TITLE
Fix castling logic

### DIFF
--- a/src/utils/move-logic.tsx
+++ b/src/utils/move-logic.tsx
@@ -67,6 +67,10 @@ export function doCastling(validPiece: Piece, realTilePos: Coordinate, allPieces
 
                 recordingData.mode = "castling queen";
             };
+
+            // Clear any castling status afterwards
+            validPiece.kingCastlingDest = null;
+            validPiece.queenCastlingDest = null;
         };
 
     return recordingData;

--- a/src/utils/move-logic.tsx
+++ b/src/utils/move-logic.tsx
@@ -56,7 +56,7 @@ export function doCastling(validPiece: Piece, realTilePos: Coordinate, allPieces
             };
 
             // Queenside castling logic
-            if (validPiece.kingCastlingDest) {
+            if (validPiece.queenCastlingDest) {
                 // Grab the Rook that's kingside.
                 const rookPos = {x: validPiece.x - 4, y: validPiece.y};
                 const actualRook = getActualRook(rookPos)!;


### PR DESCRIPTION
All it was was a misnamed variable! Additionally, cleared castling destination variables, since it was preventing the kings from moving afterwards.

Fixes #11 and #12